### PR TITLE
21 remove files in storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/nest-file",
-  "version": "0.0.28",
+  "version": "0.1.27",
   "description": "Steroids Nest File Module",
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/nest-file",
-  "version": "0.1.27",
+  "version": "0.1.0",
   "description": "Steroids Nest File Module",
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/nest-file",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Steroids Nest File Module",
   "author": "",
   "license": "MIT",

--- a/src/domain/interfaces/IFileLocalStorage.ts
+++ b/src/domain/interfaces/IFileLocalStorage.ts
@@ -2,5 +2,4 @@ import {IFileStorage} from './IFileStorage';
 
 export interface IFileLocalStorage extends IFileStorage {
     getFileNames(): string[] | null;
-    deleteFile(fileName: string): void;
 }

--- a/src/domain/interfaces/IFileStorage.ts
+++ b/src/domain/interfaces/IFileStorage.ts
@@ -9,4 +9,5 @@ export interface IFileStorage {
     read(fileModel: FileModel): Promise<Buffer>
     write(fileSaveDto: FileSaveDto, source: Readable | Buffer): Promise<FileWriteResult>
     getUrl(fileModel: FileModel | FileImageModel): string
+    deleteFile(fileName: string): void | Promise<void>;
 }

--- a/src/domain/services/FileConfigService.ts
+++ b/src/domain/services/FileConfigService.ts
@@ -106,6 +106,12 @@ export class FileConfigService implements OnModuleInit, IFileModuleConfig {
         storageName: FileStorage,
     };
 
+    /**
+     * Enable to delete file from storage after deleting data about this file in database.
+     * This option is disabled by default.
+     */
+    public deleteFileFromStorage: boolean;
+
     constructor(
         private custom: IFileModuleConfig,
     ) {
@@ -166,5 +172,7 @@ export class FileConfigService implements OnModuleInit, IFileModuleConfig {
             storageName: FileStorageEnum.LOCAL,
             ...custom.deleteLostAndTemporaryFilesByCron || {},
         };
+
+        this.deleteFileFromStorage = custom.deleteFileFromStorage;
     }
 }

--- a/src/domain/storages/MinioS3Storage.ts
+++ b/src/domain/storages/MinioS3Storage.ts
@@ -140,4 +140,17 @@ export class MinioS3Storage implements IFileStorage {
         }
         return this._client;
     }
+
+    async deleteFile(fileName: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const client = this.getClient();
+            client.removeObject(this.mainBucket, fileName, (err: any) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
 }

--- a/src/infrastructure/module.ts
+++ b/src/infrastructure/module.ts
@@ -18,6 +18,8 @@ import FileController from './controllers/FileController';
 import {IFileModuleConfig} from './config';
 import {CronJobsRegister} from './services/CronJobsRegister';
 import {DeleteLostAndTemporaryFilesService} from '../domain/services/DeleteLostAndTemporaryFilesService';
+import {FileImageSubscriber} from './subscribers/FileImageSubscriber';
+import {FileSubscriber} from './subscribers/FileSubscriber';
 
 export default (config: IFileModuleConfig) => ({
     imports: [
@@ -77,6 +79,9 @@ export default (config: IFileModuleConfig) => ({
             FileStorageFabric,
         ]),
         CronJobsRegister,
+
+        FileSubscriber,
+        FileImageSubscriber,
     ],
     exports: [
         IFileService,

--- a/src/infrastructure/subscribers/BaseFileSubscriber.ts
+++ b/src/infrastructure/subscribers/BaseFileSubscriber.ts
@@ -29,6 +29,11 @@ export abstract class BaseFileSubscriber<TTable, TModel extends IFile> implement
     async afterRemove(event: RemoveEvent<TTable>): Promise<void> {
         const removedModelInstance = this.getModelFromTable(event.databaseEntity);
 
+        if (!removedModelInstance) {
+            Sentry.captureMessage('After deleting information about file from database, invalid event was emitted');
+            return;
+        }
+
         const storage = this.storageFabric.get(removedModelInstance.storageName);
 
         try {

--- a/src/infrastructure/subscribers/BaseFileSubscriber.ts
+++ b/src/infrastructure/subscribers/BaseFileSubscriber.ts
@@ -1,0 +1,49 @@
+import {EntitySubscriberInterface, DataSource, RemoveEvent} from '@steroidsjs/typeorm';
+import {Inject, Type} from '@nestjs/common';
+import * as Sentry from '@sentry/node';
+import {FileStorageFabric} from '../../domain/services/FileStorageFabric';
+
+/**
+ * This interface contains the common FileModel and FileImageModel properties needed to delete files from storage.
+ */
+interface IFile {
+    storageName: string;
+    fileName: string;
+}
+
+/**
+ * This Susbcriber is intended to remove files from storage, information about which has been deleted from the database.
+ * Events are firing using QueryBuilder and repository/manager methods.
+ * You can see more about subscribers:
+ * - https://typeorm.io/listeners-and-subscribers#what-is-a-subscriber
+ * - https://docs.nestjs.com/techniques/database#subscribers
+ */
+export abstract class BaseFileSubscriber<TTable, TModel extends IFile> implements EntitySubscriberInterface<TTable> {
+    constructor(
+        @Inject(FileStorageFabric) protected storageFabric: FileStorageFabric,
+        dataSource: DataSource,
+    ) {
+        dataSource.subscribers.push(this);
+    }
+
+    async afterRemove(event: RemoveEvent<TTable>): Promise<void> {
+        const removedModelInstance = this.getModelFromTable(event.databaseEntity);
+
+        const storage = this.storageFabric.get(removedModelInstance.storageName);
+
+        try {
+            await storage.deleteFile(removedModelInstance.fileName);
+        } catch (error) {
+            Sentry.captureException(error);
+        }
+    }
+
+    abstract listenTo(): Type<TTable>;
+
+    /**
+     * Сonverts table object to desired model
+     * @param removedTableInstance Database representation of entity that is being removed.
+     * @returns Instance of model
+     */
+    protected abstract getModelFromTable(removedTableInstance: TTable): TModel;
+}

--- a/src/infrastructure/subscribers/FileImageSubscriber.ts
+++ b/src/infrastructure/subscribers/FileImageSubscriber.ts
@@ -1,0 +1,17 @@
+import {EventSubscriber} from '@steroidsjs/typeorm';
+import {DataMapper} from '@steroidsjs/nest/usecases/helpers/DataMapper';
+import {Type} from '@nestjs/common';
+import {BaseFileSubscriber} from './BaseFileSubscriber';
+import {FileImageModel} from '../../domain/models/FileImageModel';
+import {FileImageTable} from '../tables/FileImageTable';
+
+@EventSubscriber()
+export class FileImageSubscriber extends BaseFileSubscriber<FileImageTable, FileImageModel> {
+    listenTo(): Type<FileImageTable> {
+        return FileImageTable;
+    }
+
+    getModelFromTable(removedTableInstance: FileImageTable): FileImageModel {
+        return DataMapper.create<FileImageModel>(FileImageModel, removedTableInstance);
+    }
+}

--- a/src/infrastructure/subscribers/FileSubscriber.ts
+++ b/src/infrastructure/subscribers/FileSubscriber.ts
@@ -1,0 +1,17 @@
+import {EventSubscriber} from '@steroidsjs/typeorm';
+import {DataMapper} from '@steroidsjs/nest/usecases/helpers/DataMapper';
+import {Type} from '@nestjs/common';
+import {FileTable} from '../tables/FileTable';
+import {FileModel} from '../../domain/models/FileModel';
+import {BaseFileSubscriber} from './BaseFileSubscriber';
+
+@EventSubscriber()
+export class FileSubscriber extends BaseFileSubscriber<FileTable, FileModel> {
+    listenTo(): Type<FileTable> {
+        return FileTable;
+    }
+
+    getModelFromTable(removedTableInstance: FileTable): FileModel {
+        return DataMapper.create<FileModel>(FileModel, removedTableInstance);
+    }
+}


### PR DESCRIPTION
https://gitlab.kozhindev.com/steroids/steroids-nest/-/issues/21

Реализовал удаление файлов из хранилища, когда информация о файлах удаляется из бд. Рассматривал следующие варианты:
- удаление после вызова метода репозитория от steroids-nest https://github.com/steroids/nest/blob/main/src/infrastructure/repositories/CrudRepository.ts#L202 
- удаление с помощью `Subscriber`

Для этого выбрал вариант с `Subscriber` от typeorm в основном по следующей причине:
- евенты выбрасываются при использовании методов репозитория/менеджера, а также `QueryBuilder` - https://typeorm.io/listeners-and-subscribers#what-is-a-subscriber.  В CRUD репозитории от steroids-nest удаление моделей производится с помощью `EntityManager` - https://github.com/steroids/nest/blob/main/src/infrastructure/repositories/CrudRepository.ts#L220C10-L220C10 В проектах же может применяться для удаления `QueryBuilder`. Это значит следующее: если вызывать метод удаления файла из хранилища в `CrudRepository` внутри метода `remove()`, то при удалении через `QueryBuilder`  метод удаления файла из хранилища не будет вызван.