### PR TITLE
#128 feat: FileUploadInterceptor

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@nestjs/platform-express": "^9.2.1",
     "@nestjs/schedule": "^4.0.0",
     "@nestjs/swagger": "^6.1.4",
-    "nestjs-command": "^3.1.3",
     "cron": "^3.1.6",
     "express": "^4.18.2",
     "lodash": "^4.17.21",
@@ -22,6 +21,8 @@
     "mime-types": "^2.1.35",
     "minio": "7.1.3",
     "multer": "^1.4.5-lts.1",
+    "nestjs-command": "^3.1.3",
+    "rxjs": "^7.8.2",
     "sharp": "^0.34.1",
     "stream-mime-type": "^1.0.2"
   },

--- a/src/domain/services/FileTypeService.ts
+++ b/src/domain/services/FileTypeService.ts
@@ -1,6 +1,6 @@
 import {DataMapper} from '@steroidsjs/nest/usecases/helpers/DataMapper';
 import {FileUploadOptions} from '../dtos/FileUploadOptions';
-import { IFileTypeService } from '../interfaces/IFileTypeService';
+import {IFileTypeService} from '../interfaces/IFileTypeService';
 
 /*
     Basic implementation of a service that, based on the fileType field, sets the necessary parameters for
@@ -11,10 +11,10 @@ export class FileTypeService implements IFileTypeService {
     constructor() {}
 
     public async getFileUploadOptionsByType(fileType: string) {
-        return DataMapper.create(FileUploadOptions, {
+        return DataMapper.create<FileUploadOptions>(FileUploadOptions, {
             folder: null,
-            maxSizeMb: null,
-            mimeTypes: null,
-        });
+            maxSizeMb: 10,
+            mimeTypes: ['image/png'],
+        } as object);
     }
 }

--- a/src/domain/services/FileTypeService.ts
+++ b/src/domain/services/FileTypeService.ts
@@ -2,6 +2,8 @@ import {DataMapper} from '@steroidsjs/nest/usecases/helpers/DataMapper';
 import {FileUploadOptions} from '../dtos/FileUploadOptions';
 import {IFileTypeService} from '../interfaces/IFileTypeService';
 
+const DEFAULT_FILE_MAX_SIZE_MB = 10;
+
 /*
     Basic implementation of a service that, based on the fileType field, sets the necessary parameters for
     this type of file - their maximum size, format, directory, etc.
@@ -13,8 +15,8 @@ export class FileTypeService implements IFileTypeService {
     public async getFileUploadOptionsByType(fileType: string) {
         return DataMapper.create<FileUploadOptions>(FileUploadOptions, {
             folder: null,
-            maxSizeMb: 10,
-            mimeTypes: ['image/png'],
+            maxSizeMb: DEFAULT_FILE_MAX_SIZE_MB,
+            mimeTypes: [],
         } as object);
     }
 }

--- a/src/infrastructure/controllers/FileController.ts
+++ b/src/infrastructure/controllers/FileController.ts
@@ -1,14 +1,14 @@
-import {Controller, Inject, Put, Query, UploadedFile} from '@nestjs/common';
+import {Controller, Inject, Put, Query, UploadedFile, UseInterceptors} from '@nestjs/common';
 import {ApiOkResponse, ApiQuery, ApiTags} from '@nestjs/swagger';
 import {DataMapper} from '@steroidsjs/nest/usecases/helpers/DataMapper';
 import {IFileService} from '@steroidsjs/nest-modules/file/services/IFileService';
-import {FileUpload} from '../decorators/FileUpload';
 import {IExpressSource} from '../../domain/interfaces/IExpressSource';
 import {FileUploadOptions} from '../../domain/dtos/FileUploadOptions';
 import {FileExpressSourceDto} from '../../domain/dtos/sources/FileExpressSourceDto';
 import {FileUploadDto} from '../../domain/dtos/FileUploadDto';
 import {FileImageSchema} from '../schemas/FileImageSchema';
 import {FileSchema} from '../schemas/FileSchema';
+import {FileUploadInterceptor} from '../interceptors/FileUploadInterceptor';
 
 @Controller('/file')
 @ApiTags('Файлы')
@@ -20,10 +20,10 @@ export default class FileController {
     }
 
     @Put('/upload-photo')
-    @FileUpload()
     // @todo поправить useFile чтобы при загрузке картинок через FileField передавался Admin-Authorization
     // @AuthPermissions(PERMISSION_AUTH_ADMIN_AUTHORIZED)
     // @UseGuards(AdminJwtAuthGuard)
+    @UseInterceptors(FileUploadInterceptor)
     @ApiQuery({type: FileUploadDto})
     @ApiOkResponse({type: FileImageSchema})
     async photos(
@@ -42,9 +42,9 @@ export default class FileController {
     @Put('/upload-file')
     // @todo поправить useFile чтобы при загрузке картинок через FileField передавался Admin-Authorization
     // @AuthPermissions(PERMISSION_AUTH_ADMIN_AUTHORIZED)
+    @UseInterceptors(FileUploadInterceptor)
     @ApiQuery({type: FileUploadDto})
     @ApiOkResponse({type: FileSchema})
-    @FileUpload()
     async files(
         @UploadedFile() file: IExpressSource,
         @Query()dto: FileUploadDto,

--- a/src/infrastructure/decorators/FileUpload.ts
+++ b/src/infrastructure/decorators/FileUpload.ts
@@ -1,16 +1,17 @@
+import {extname, join} from 'path';
 import {applyDecorators, UnsupportedMediaTypeException, UseInterceptors} from '@nestjs/common';
 import {FileInterceptor} from '@nestjs/platform-express';
 import {diskStorage} from 'multer';
-import {extname, join} from 'path';
 
 const MAX_BITS_SIZE = 25165824; // 10 mb;
 
 interface IFileUploadOptions {
     maxFileSize?: number,
     fieldName?: string,
-    allowedMimeTypes?: string[];
+    allowedMimeTypes?: string[],
 }
 
+/** @deprecated Use FileUploadInterceptor */
 export function FileUpload(options?: IFileUploadOptions) {
     return applyDecorators(
         UseInterceptors(

--- a/src/infrastructure/interceptors/FileUploadInterceptor.ts
+++ b/src/infrastructure/interceptors/FileUploadInterceptor.ts
@@ -1,0 +1,74 @@
+import {extname, join} from 'path';
+import {
+    Injectable,
+    NestInterceptor,
+    ExecutionContext,
+    CallHandler,
+    UnsupportedMediaTypeException,
+    Inject, PayloadTooLargeException,
+} from '@nestjs/common';
+import {Observable, switchMap} from 'rxjs';
+import * as multer from 'multer';
+import {Request} from 'express';
+import {IFileTypeService} from '../../domain/interfaces/IFileTypeService';
+
+// Ключ в объекте request, по которому будет лежать загруженный файл. По-умолчанию декоратор UploadedFile из NestJS ожидает значение file
+const FILE_QUERY_KEY = 'file';
+
+@Injectable()
+export class FileUploadInterceptor implements NestInterceptor {
+    constructor(
+        @Inject(IFileTypeService)
+        private readonly fileTypeService: IFileTypeService,
+    ) {}
+
+    async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<void>> {
+        const ctx = context.switchToHttp();
+        const request = ctx.getRequest<Request>();
+        const response = ctx.getResponse();
+
+        const fileType = request.query.fileType as string;
+
+        const config = await this.fileTypeService.getFileUploadOptionsByType(fileType);
+
+        const storage = multer.diskStorage({
+            // TODO use FileConfigService
+            destination: process.env.APP_FILE_STORAGE_ROOT_PATH || join(process.cwd(), '../files/uploaded'),
+
+            filename: (r, file, callback) => {
+                const randomName = Array(24).fill(null)
+                    .map(() => (Math.round(Math.random() * 16)).toString(16)).join('');
+                return callback(null, `${randomName}${extname(file.originalname)}`);
+            },
+        });
+
+        const upload = multer({
+            storage,
+            limits: {fileSize: config.maxSizeMb * 1024 * 1024},
+            fileFilter: (req, file, callback: multer.FileFilterCallback) => {
+                if (config.mimeTypes?.length && !config.mimeTypes.includes(file.mimetype)) {
+                    callback(new UnsupportedMediaTypeException(
+                        `Недопустимый тип файла: ${file.mimetype}. Допустимы форматы ${config.mimeTypes.join(', ')}`,
+                    ));
+                }
+                callback(null, true);
+            },
+        }).single(FILE_QUERY_KEY);
+
+        return new Observable<void>(observer => {
+            upload(request, response, err => {
+                if (err.code === 'LIMIT_FILE_SIZE') {
+                    observer.error(new PayloadTooLargeException(`Файл слишком большой. Максимальный размер: ${config.maxSizeMb}MB`));
+                }
+                if (err) {
+                    observer.error(err);
+                } else {
+                    observer.next();
+                    observer.complete();
+                }
+            });
+        }).pipe(
+            switchMap(() => next.handle()),
+        );
+    }
+}

--- a/src/infrastructure/interceptors/FileUploadInterceptor.ts
+++ b/src/infrastructure/interceptors/FileUploadInterceptor.ts
@@ -57,11 +57,11 @@ export class FileUploadInterceptor implements NestInterceptor {
 
         return new Observable<void>(observer => {
             upload(request, response, err => {
-                if (err.code === 'LIMIT_FILE_SIZE') {
-                    observer.error(new PayloadTooLargeException(`Файл слишком большой. Максимальный размер: ${config.maxSizeMb}MB`));
-                }
                 if (err) {
-                    observer.error(err);
+                    const error = err.code === 'LIMIT_FILE_SIZE'
+                        ? new PayloadTooLargeException(`Файл слишком большой. Максимальный размер: ${config.maxSizeMb}MB`)
+                        : err;
+                    observer.error(error);
                 } else {
                     observer.next();
                     observer.complete();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4351,6 +4351,13 @@ rxjs@^7.5.5:
   dependencies:
     tslib "^2.1.0"
 
+rxjs@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"


### PR DESCRIPTION
На замену декоратору FileUpload (который внутри использует FileInterceptor из Nest) написал собственный Interceptor, у которого есть доступ к DI.
Он обращается в FileTypeService, получает конфиг для загружаемого типа файла и валидирует его по этому конфигу.  В перспективе можно будет здесь же обращаться в request, в котором будет лежать моделька User, и по его контексту добавлять дополнительную логику (например, расширенные лимиты для админа).  Я пока что этого не делал, так как у нас отключены гарды на эндпоинтах