### PR TITLE
#189 fix:  remove fileStorageParams from IFileStorage.write and use named transient storages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Steroids Nest File
 
+### Fixes
+
+[Migration guide]()
+
+- `IFileStorage.write` больше не принимает в качестве аргумента `fileStorageParams`, вместо этого хранилища сами берут эти настройки
+из `IGetFileStorageParamsUseCase`
+- Добавлен токен `FILE_STORAGES_TOKEN`, по которому провайдится объект с хранилищами и их названиями
+- Хранилища теперь имеют injection scope `TRANSIENT`, что позволяет создать несколько экземпляров одного хранилища с разным конфигом
+- Использование `FileStorageEnum` в качестве типа обновлено на `FileStorageNameType`
+
 ## [0.4.1](https://github.com/steroids/nest-file/compare/0.4.0...0.4.1) (2025-12-18)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Steroids Nest File
 
+## Unreleased
+
 ### Fixes
 
-[Migration guide]()
+[Migration guide](docs/MigrationGuide.md#провайдинг-хранилищ-после-обновления)
 
 - `IFileStorage.write` больше не принимает в качестве аргумента `fileStorageParams`, вместо этого хранилища сами берут эти настройки
 из `IGetFileStorageParamsUseCase`
 - Добавлен токен `FILE_STORAGES_TOKEN`, по которому провайдится объект с хранилищами и их названиями
 - Хранилища теперь имеют injection scope `TRANSIENT`, что позволяет создать несколько экземпляров одного хранилища с разным конфигом
-- Использование `FileStorageEnum` в качестве типа обновлено на `FileStorageNameType`
+- Использование `FileStorageEnum` в качестве типа обновлено на `string`
 
 ## [0.4.1](https://github.com/steroids/nest-file/compare/0.4.0...0.4.1) (2025-12-18)
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,107 @@ APP_FILE_STORAGE_S3_ROOT_URL=https://storage.yandexcloud.net/arm-supervisor
    - APP_FILE_STORAGE_S3_ROOT_URL - адрес S3 хранилища, включая бакет
    - APP_FILE_STORAGE_S3_REGION - регион S3 хранилища
 
-### Параметры загрузки файла в определенное хранилище
+## Провайдинг нескольких хранилищ
 
-В проекте по токену GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN можно положить в DI-контейнер юзкейс, возвращающий параметры загрузки в определенный тип хранилища для конкретного fileType.
-Данный юзкейс будет вызван при загрузке файла в FileService и FileImageService
+По умолчанию модуль провайдит два хранилища: `local` и `minio_s3`.
+Если в проекте нужно использовать несколько экземпляров одного хранилища с разными настройками, добавьте настройки каждого хранилища в `storages` и запровайдите экземпляры по токену `FILE_STORAGES_TOKEN`.
+Ключи в `storages` используются как `storageName`.
+
+```ts
+import {ModuleRef} from '@nestjs/core';
+import coreModule from '@steroidsjs/nest-file';
+import {FILE_STORAGES_TOKEN} from '@steroidsjs/nest-file/domain/interfaces/IFileStorage';
+import {MinioS3Storage} from '@steroidsjs/nest-file/domain/storages/MinioS3Storage';
+
+@Module({
+    ...coreModule,
+    config: () => {
+        const coreConfig = coreModule.config();
+        return {
+            ...coreConfig,
+            defaultStorageName: 'minio_s3_1',
+            storages: {
+                ...coreConfig.storages,
+                minio_s3_1: {
+                    mainBucket: 'files',
+                    rootUrl: 'https://storage.example.com/files',
+                },
+                minio_s3_2: {
+                    mainBucket: 'images',
+                    rootUrl: 'https://storage.example.com/images',
+                },
+            },
+        };
+    },
+    module: (config) => {
+        const module = coreModule.module(config);
+        return {
+            ...module,
+            providers: [
+                ...module.providers,
+                {
+                    provide: FILE_STORAGES_TOKEN,
+                    inject: [ModuleRef],
+                    useFactory: async (moduleRef: ModuleRef) => ({
+                        minio_s3_1: await moduleRef.resolve(MinioS3Storage),
+                        minio_s3_2: await moduleRef.resolve(MinioS3Storage),
+                    }),
+                },
+            ],
+        };
+    },
+})
+export class FileModule {}
+```
+
+После этого нужное хранилище можно выбрать при загрузке:
+
+```ts
+await fileService.upload({
+    source,
+    storageName: 'minio_s3_2',
+});
+```
+
+### Параметры загрузки файла в хранилище
+
+Если параметры записи зависят от `fileType` или имени хранилища, в проекте можно запровайдить сервис, реализующий `IGetFileStorageParamsUseCase`, по токену `GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN`.
+Хранилища вызывают этот use case при записи файла.
+
+```ts
+import {
+    GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN,
+    IGetFileStorageParamsUseCase,
+} from '@steroidsjs/nest-file/usecases/getFileStorageParams/interfaces/IGetFileStorageParamsUseCase';
+
+@Injectable()
+class GetFileStorageParamsUseCase implements IGetFileStorageParamsUseCase {
+    async handle(fileType: string | undefined, storageName: string) {
+        if (storageName === 'minio_s3_2' && fileType === 'avatar') {
+            return {
+                'Cache-Control': 'public, max-age=31536000',
+            };
+        }
+
+        return {};
+    }
+}
+
+@Module({
+    ...coreModule,
+    module: (config) => {
+        const module = coreModule.module(config);
+        return {
+            ...module,
+            providers: [
+                ...module.providers,
+                {
+                    provide: GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN,
+                    useClass: GetFileStorageParamsUseCase,
+                },
+            ],
+        };
+    },
+})
+export class FileModule {}
+```

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -1,5 +1,43 @@
 # Steroids Nest File Migration Guide
 
+### Провайдинг хранилищ
+
+Объект с хранилищами теперь провайдятся по токену `FILE_STORAGES_TOKEN`, а так же хранилища имеют injection scope `TRANSIENT`.
+Это позволяет создавать несколько экземпляров одного хранилища с разными конфигурациями.
+Чтобы этим воспользоваться, нужно:
+
+1. Запровайдить `FILE_STORAGES_TOKEN` (нужно использовать именно `moduleRef.resolve`, так как используется `TRANSIENT` scope, возвращая новый экземпляр):
+```typescript
+{
+    provide: FILE_STORAGES_TOKEN,
+    inject: [ModuleRef],
+    useFactory: async (moduleRef: ModuleRef) => ({
+        ['minio_s3_1']: await moduleRef.resolve(MinioS3Storage),
+        ['minio_s3_2']: await moduleRef.resolve(MinioS3Storage),
+    }),
+},
+```
+
+2. В конфиге модуля `FileModule` указать в поле `storages` поля с теми же названиями хранилищ, что и запровайденные выше:
+
+```typescript
+@Module({
+    ...coreModule,
+    config: () => {
+        const coreConfig = coreModule.config();
+        return {
+            ...coreConfig,
+            storages: {
+                ...coreConfig.storages,
+                minio_s3_1: {},
+                minio_s3_2: {},
+            },
+        };
+    },
+})
+export class FileModule {}
+```
+
 ## [0.4.0](../CHANGELOG.md#040-2025-12-18) (2025-12-18)
 
 ### Параметры загрузки в хранилище по fileType

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -1,24 +1,13 @@
 # Steroids Nest File Migration Guide
 
-### Провайдинг хранилищ
+### Провайдинг хранилищ после обновления
 
-Объект с хранилищами теперь провайдятся по токену `FILE_STORAGES_TOKEN`, а так же хранилища имеют injection scope `TRANSIENT`.
-Это позволяет создавать несколько экземпляров одного хранилища с разными конфигурациями.
-Чтобы этим воспользоваться, нужно:
+`FileStorageFactory` теперь получает хранилища из DI по токену `FILE_STORAGES_TOKEN`.
+Если проект использует стандартный `coreModule.module(config)` и не переопределяет провайдинг хранилищ, токен уже настроен внутри пакета.
+Если проект переопределяет providers, использует кастомные хранилища или несколько экземпляров одного хранилища с разными настройками, нужно:
 
-1. Запровайдить `FILE_STORAGES_TOKEN` (нужно использовать именно `moduleRef.resolve`, так как используется `TRANSIENT` scope, возвращая новый экземпляр):
-```typescript
-{
-    provide: FILE_STORAGES_TOKEN,
-    inject: [ModuleRef],
-    useFactory: async (moduleRef: ModuleRef) => ({
-        ['minio_s3_1']: await moduleRef.resolve(MinioS3Storage),
-        ['minio_s3_2']: await moduleRef.resolve(MinioS3Storage),
-    }),
-},
-```
-
-2. В конфиге модуля `FileModule` указать в поле `storages` поля с теми же названиями хранилищ, что и запровайденные выше:
+1. Добавить настройки каждого хранилища в `FileModule.config.storages`.
+   Ключи в `storages` будут использоваться как `storageName`.
 
 ```typescript
 @Module({
@@ -37,6 +26,23 @@
 })
 export class FileModule {}
 ```
+
+2. Запровайдить эти же ключи по токену `FILE_STORAGES_TOKEN`.
+   Для `TRANSIENT` хранилищ нужно использовать `moduleRef.resolve`, чтобы получить отдельный экземпляр для каждого имени.
+
+```typescript
+{
+    provide: FILE_STORAGES_TOKEN,
+    inject: [ModuleRef],
+    useFactory: async (moduleRef: ModuleRef) => ({
+        minio_s3_1: await moduleRef.resolve(MinioS3Storage),
+        minio_s3_2: await moduleRef.resolve(MinioS3Storage),
+    }),
+},
+```
+
+3. Убрать передачу `fileStorageParams` в `IFileStorage.write`.
+   Параметры записи, зависящие от `fileType` или `storageName`, нужно перенести в `IGetFileStorageParamsUseCase` и запровайдить его по токену `GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN`.
 
 ## [0.4.0](../CHANGELOG.md#040-2025-12-18) (2025-12-18)
 

--- a/src/domain/dtos/FileUploadOptions.ts
+++ b/src/domain/dtos/FileUploadOptions.ts
@@ -1,8 +1,8 @@
 import {BooleanField, IntegerField, StringField} from '@steroidsjs/nest/infrastructure/decorators/fields';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileExpressSourceDto} from './sources/FileExpressSourceDto';
 import {FileLocalSourceDto} from './sources/FileLocalSourceDto';
 import {FileStreamSourceDto} from './sources/FileStreamSourceDto';
-import FileStorageEnum from '../enums/FileStorageEnum';
 
 export class FileUploadOptions {
     @StringField({
@@ -33,7 +33,7 @@ export class FileUploadOptions {
         label: 'Storage name (file, aws, ...)',
         nullable: true,
     })
-    storageName: FileStorageEnum;
+    storageName: FileStorageNameType;
 
     @IntegerField({
         label: 'Max file size in megabyte',

--- a/src/domain/dtos/FileUploadOptions.ts
+++ b/src/domain/dtos/FileUploadOptions.ts
@@ -1,5 +1,4 @@
 import {BooleanField, IntegerField, StringField} from '@steroidsjs/nest/infrastructure/decorators/fields';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileExpressSourceDto} from './sources/FileExpressSourceDto';
 import {FileLocalSourceDto} from './sources/FileLocalSourceDto';
 import {FileStreamSourceDto} from './sources/FileStreamSourceDto';
@@ -33,7 +32,7 @@ export class FileUploadOptions {
         label: 'Storage name (file, aws, ...)',
         nullable: true,
     })
-    storageName: FileStorageNameType;
+    storageName: string;
 
     @IntegerField({
         label: 'Max file size in megabyte',

--- a/src/domain/dtos/events/FileRemovedEventDto.ts
+++ b/src/domain/dtos/events/FileRemovedEventDto.ts
@@ -1,5 +1,5 @@
-import { EnumField, IntegerField, StringField } from '@steroidsjs/nest/infrastructure/decorators/fields';
-import FileStorageEnum from '../../enums/FileStorageEnum';
+import {IntegerField, StringField} from '@steroidsjs/nest/infrastructure/decorators/fields';
+import {FileStorageNameType} from '../../types/FileStorageNameType';
 
 export class FileRemovedEventDto {
     static eventName = Symbol('File.Removed');
@@ -13,8 +13,6 @@ export class FileRemovedEventDto {
     @StringField()
     fileName: string;
 
-    @EnumField({
-        enum: FileStorageEnum,
-    })
-    storageName: FileStorageEnum;
+    @StringField()
+    storageName: FileStorageNameType;
 }

--- a/src/domain/dtos/events/FileRemovedEventDto.ts
+++ b/src/domain/dtos/events/FileRemovedEventDto.ts
@@ -1,5 +1,4 @@
 import {IntegerField, StringField} from '@steroidsjs/nest/infrastructure/decorators/fields';
-import {FileStorageNameType} from '../../types/FileStorageNameType';
 
 export class FileRemovedEventDto {
     static eventName = Symbol('File.Removed');
@@ -14,5 +13,5 @@ export class FileRemovedEventDto {
     fileName: string;
 
     @StringField()
-    storageName: FileStorageNameType;
+    storageName: string;
 }

--- a/src/domain/interfaces/IFileImageRepository.ts
+++ b/src/domain/interfaces/IFileImageRepository.ts
@@ -1,9 +1,9 @@
 import {ICrudRepository} from '@steroidsjs/nest/usecases/interfaces/ICrudRepository';
 import {FileImageModel} from '../models/FileImageModel';
-import FileStorageEnum from '../enums/FileStorageEnum';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 
 export const IFileImageRepository = 'IFileImageRepository';
 
 export interface IFileImageRepository extends ICrudRepository<FileImageModel> {
-    getFilesPathsByStorageName: (storageName: FileStorageEnum) => Promise<string[] | null>;
+    getFilesPathsByStorageName: (storageName: FileStorageNameType) => Promise<string[] | null>,
 }

--- a/src/domain/interfaces/IFileImageRepository.ts
+++ b/src/domain/interfaces/IFileImageRepository.ts
@@ -1,9 +1,8 @@
 import {ICrudRepository} from '@steroidsjs/nest/usecases/interfaces/ICrudRepository';
 import {FileImageModel} from '../models/FileImageModel';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 
 export const IFileImageRepository = 'IFileImageRepository';
 
 export interface IFileImageRepository extends ICrudRepository<FileImageModel> {
-    getFilesPathsByStorageName: (storageName: FileStorageNameType) => Promise<string[] | null>,
+    getFilesPathsByStorageName: (storageName: string) => Promise<string[] | null>,
 }

--- a/src/domain/interfaces/IFileRepository.ts
+++ b/src/domain/interfaces/IFileRepository.ts
@@ -1,12 +1,12 @@
 import {ICrudRepository} from '@steroidsjs/nest/usecases/interfaces/ICrudRepository';
 import {FileModel} from '../models/FileModel';
-import FileStorageEnum from '../enums/FileStorageEnum';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 
 export const IFileRepository = 'IFileRepository';
 
 export interface IFileRepository extends ICrudRepository<FileModel> {
-    getFileWithDocument: (fileName: string) => Promise<FileModel>;
-    getFilesPathsByStorageName: (storageName: FileStorageEnum) => Promise<string[] | null>;
+    getFileWithDocument: (fileName: string) => Promise<FileModel>,
+    getFilesPathsByStorageName: (storageName: FileStorageNameType) => Promise<string[] | null>,
     getUnusedFilesIds: (config: {
         fileNameLike: string,
         ignoredTables: string[],

--- a/src/domain/interfaces/IFileRepository.ts
+++ b/src/domain/interfaces/IFileRepository.ts
@@ -1,12 +1,11 @@
 import {ICrudRepository} from '@steroidsjs/nest/usecases/interfaces/ICrudRepository';
 import {FileModel} from '../models/FileModel';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 
 export const IFileRepository = 'IFileRepository';
 
 export interface IFileRepository extends ICrudRepository<FileModel> {
     getFileWithDocument: (fileName: string) => Promise<FileModel>,
-    getFilesPathsByStorageName: (storageName: FileStorageNameType) => Promise<string[] | null>,
+    getFilesPathsByStorageName: (storageName: string) => Promise<string[] | null>,
     getUnusedFilesIds: (config: {
         fileNameLike: string,
         ignoredTables: string[],

--- a/src/domain/interfaces/IFileStorage.ts
+++ b/src/domain/interfaces/IFileStorage.ts
@@ -15,3 +15,5 @@ export interface IFileStorage {
     deleteFile(fileName: string): void | Promise<void>,
     storageName?: FileStorageNameType,
 }
+
+export const FILE_STORAGES_TOKEN = 'file_storages_token';

--- a/src/domain/interfaces/IFileStorage.ts
+++ b/src/domain/interfaces/IFileStorage.ts
@@ -1,5 +1,6 @@
 import {Readable} from 'stream';
 import {FileWriteResult} from '../dtos/FileWriteResult';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 import {IFileReadable} from './IFileReadable';
 import {IFileWritable} from './IFileWritable';
 
@@ -9,8 +10,8 @@ export interface IFileStorage {
     write(
         file: IFileWritable,
         source: Readable | Buffer,
-        fileStorageParams?: Record<string, any> | null,
     ): Promise<FileWriteResult>,
     getUrl(file: IFileReadable): string,
     deleteFile(fileName: string): void | Promise<void>,
+    storageName?: FileStorageNameType,
 }

--- a/src/domain/interfaces/IFileStorage.ts
+++ b/src/domain/interfaces/IFileStorage.ts
@@ -1,6 +1,5 @@
 import {Readable} from 'stream';
 import {FileWriteResult} from '../dtos/FileWriteResult';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 import {IFileReadable} from './IFileReadable';
 import {IFileWritable} from './IFileWritable';
 
@@ -13,7 +12,7 @@ export interface IFileStorage {
     ): Promise<FileWriteResult>,
     getUrl(file: IFileReadable): string,
     deleteFile(fileName: string): void | Promise<void>,
-    storageName?: FileStorageNameType,
+    storageName: string,
 }
 
 export const FILE_STORAGES_TOKEN = 'file_storages_token';

--- a/src/domain/interfaces/IFileStorageFactory.ts
+++ b/src/domain/interfaces/IFileStorageFactory.ts
@@ -1,8 +1,8 @@
-import {FileStorageEnum} from '../enums/FileStorageEnum';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 import {IFileStorage} from './IFileStorage';
 
 export const IFileStorageFactory = 'IFileStorageFactory';
 
 export interface IFileStorageFactory {
-    get: (name: FileStorageEnum) => IFileStorage;
+    get: (name: FileStorageNameType) => IFileStorage,
 }

--- a/src/domain/interfaces/IFileStorageFactory.ts
+++ b/src/domain/interfaces/IFileStorageFactory.ts
@@ -1,8 +1,7 @@
-import {FileStorageNameType} from '../types/FileStorageNameType';
 import {IFileStorage} from './IFileStorage';
 
 export const IFileStorageFactory = 'IFileStorageFactory';
 
 export interface IFileStorageFactory {
-    get: (name: FileStorageNameType) => IFileStorage,
+    get: (name: string) => IFileStorage,
 }

--- a/src/domain/interfaces/IFileWritable.ts
+++ b/src/domain/interfaces/IFileWritable.ts
@@ -3,4 +3,5 @@ import {IFileReadable} from './IFileReadable';
 export interface IFileWritable extends IFileReadable {
     fileSize: number,
     fileMimeType: string,
+    fileType?: string,
 }

--- a/src/domain/models/FileImageModel.ts
+++ b/src/domain/models/FileImageModel.ts
@@ -2,10 +2,10 @@ import {
     PrimaryKeyField,
     RelationField,
     StringField,
-    CreateTimeField, IntegerField, RelationIdField, BooleanField, EnumField,
+    CreateTimeField, IntegerField, RelationIdField, BooleanField,
 } from '@steroidsjs/nest/infrastructure/decorators/fields';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileModel} from './FileModel';
-import FileStorageEnum from '../enums/FileStorageEnum';
 
 /**
  * Миниатюры изображений файлов
@@ -26,12 +26,11 @@ export class FileImageModel {
     })
     url: string;
 
-    @EnumField({
+    @StringField({
         label: 'Имя хранилища',
-        enum: FileStorageEnum,
         nullable: true,
     })
-    storageName: FileStorageEnum;
+    storageName: FileStorageNameType;
 
     @StringField({
         label: 'Название файла',

--- a/src/domain/models/FileImageModel.ts
+++ b/src/domain/models/FileImageModel.ts
@@ -4,7 +4,6 @@ import {
     StringField,
     CreateTimeField, IntegerField, RelationIdField, BooleanField,
 } from '@steroidsjs/nest/infrastructure/decorators/fields';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileModel} from './FileModel';
 
 /**
@@ -30,7 +29,7 @@ export class FileImageModel {
         label: 'Имя хранилища',
         nullable: true,
     })
-    storageName: FileStorageNameType;
+    storageName: string;
 
     @StringField({
         label: 'Название файла',

--- a/src/domain/models/FileModel.ts
+++ b/src/domain/models/FileModel.ts
@@ -2,9 +2,9 @@ import {
     RelationField,
     PrimaryKeyField,
     StringField,
-    CreateTimeField, IntegerField, UidField, EnumField,
+    CreateTimeField, IntegerField, UidField,
 } from '@steroidsjs/nest/infrastructure/decorators/fields';
-import FileStorageEnum from '../enums/FileStorageEnum';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileImageModel} from './FileImageModel';
 
 /**
@@ -38,12 +38,11 @@ export class FileModel {
     })
     url: string;
 
-    @EnumField({
+    @StringField({
         label: 'Имя хранилища',
         nullable: true,
-        enum: FileStorageEnum,
     })
-    storageName: FileStorageEnum;
+    storageName: FileStorageNameType;
 
     @StringField({
         label: 'Название сохраненного файла',

--- a/src/domain/models/FileModel.ts
+++ b/src/domain/models/FileModel.ts
@@ -4,7 +4,6 @@ import {
     StringField,
     CreateTimeField, IntegerField, UidField,
 } from '@steroidsjs/nest/infrastructure/decorators/fields';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileImageModel} from './FileImageModel';
 
 /**
@@ -42,7 +41,7 @@ export class FileModel {
         label: 'Имя хранилища',
         nullable: true,
     })
-    storageName: FileStorageNameType;
+    storageName: string;
 
     @StringField({
         label: 'Название сохраненного файла',

--- a/src/domain/services/DeleteLostAndTemporaryFilesService.ts
+++ b/src/domain/services/DeleteLostAndTemporaryFilesService.ts
@@ -2,11 +2,11 @@ import * as Sentry from '@sentry/node';
 import {Inject, Optional} from '@nestjs/common';
 import {IFileLocalStorage} from '../interfaces/IFileLocalStorage';
 import {IFileStorageFactory} from '../interfaces/IFileStorageFactory';
-import FileStorageEnum from '../enums/FileStorageEnum';
 import {
     GetFileModelsPathUsecaseToken,
     IGetFileModelsPathUsecase,
 } from '../../usecases/getFilePathModels/interfaces/IGetFileModelsPathUsecase';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 
 export class DeleteLostAndTemporaryFilesService {
     constructor(
@@ -23,7 +23,7 @@ export class DeleteLostAndTemporaryFilesService {
      * - in MinioS3Storage class implement extended IFileStorage interface
      * - return in getStorage() method object that implements IFileStorage interface
      */
-    async deleteLostAndTemporaryFiles(storageName: FileStorageEnum): Promise<void> {
+    async deleteLostAndTemporaryFiles(storageName: FileStorageNameType): Promise<void> {
         const storage = this.getStorage(storageName);
         if (!storage) {
             return;
@@ -34,7 +34,7 @@ export class DeleteLostAndTemporaryFilesService {
         }
     }
 
-    async getLostAndTemporaryFilesPaths(storageName: FileStorageEnum): Promise<string[]> {
+    async getLostAndTemporaryFilesPaths(storageName: FileStorageNameType): Promise<string[]> {
         if (!this.getFileModelsPathUsecase) {
             throw new Error('GetFileModelsPathUsecase is not provided');
         }
@@ -64,7 +64,7 @@ export class DeleteLostAndTemporaryFilesService {
         return lostAndTemporaryFilesPaths;
     }
 
-    private getStorage(storageName: FileStorageEnum): IFileLocalStorage {
+    private getStorage(storageName: FileStorageNameType): IFileLocalStorage {
         try {
             return this.fileStorageFactory.get(storageName) as IFileLocalStorage;
         } catch (error) {

--- a/src/domain/services/DeleteLostAndTemporaryFilesService.ts
+++ b/src/domain/services/DeleteLostAndTemporaryFilesService.ts
@@ -6,7 +6,6 @@ import {
     GetFileModelsPathUsecaseToken,
     IGetFileModelsPathUsecase,
 } from '../../usecases/getFilePathModels/interfaces/IGetFileModelsPathUsecase';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 
 export class DeleteLostAndTemporaryFilesService {
     constructor(
@@ -23,7 +22,7 @@ export class DeleteLostAndTemporaryFilesService {
      * - in MinioS3Storage class implement extended IFileStorage interface
      * - return in getStorage() method object that implements IFileStorage interface
      */
-    async deleteLostAndTemporaryFiles(storageName: FileStorageNameType): Promise<void> {
+    async deleteLostAndTemporaryFiles(storageName: string): Promise<void> {
         const storage = this.getStorage(storageName);
         if (!storage) {
             return;
@@ -34,7 +33,7 @@ export class DeleteLostAndTemporaryFilesService {
         }
     }
 
-    async getLostAndTemporaryFilesPaths(storageName: FileStorageNameType): Promise<string[]> {
+    async getLostAndTemporaryFilesPaths(storageName: string): Promise<string[]> {
         if (!this.getFileModelsPathUsecase) {
             throw new Error('GetFileModelsPathUsecase is not provided');
         }
@@ -64,7 +63,7 @@ export class DeleteLostAndTemporaryFilesService {
         return lostAndTemporaryFilesPaths;
     }
 
-    private getStorage(storageName: FileStorageNameType): IFileLocalStorage {
+    private getStorage(storageName: string): IFileLocalStorage {
         try {
             return this.fileStorageFactory.get(storageName) as IFileLocalStorage;
         } catch (error) {

--- a/src/domain/services/FileConfigService.ts
+++ b/src/domain/services/FileConfigService.ts
@@ -1,12 +1,13 @@
-import {toInteger as _toInteger} from 'lodash';
-import {OnModuleInit} from '@nestjs/common';
 import {join} from 'path';
+import {toInteger as _toInteger} from 'lodash';
+import {Injectable, OnModuleInit} from '@nestjs/common';
 import {CronExpression} from '@nestjs/schedule';
 import {normalizeBoolean} from '@steroidsjs/nest/infrastructure/decorators/fields/BooleanField';
 import FileStorageEnum from '../enums/FileStorageEnum';
 import FilePreviewEnum from '../enums/FilePreviewEnum';
 import {IFilePreviewOptions} from '../interfaces/IFilePreviewOptions';
 import {IFileModuleConfig} from '../../infrastructure/config';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 
 const getStoragesConfig = (storagesConfig: IFileModuleConfig['storages'] = {}) => {
     const localStorageConfig = {
@@ -36,13 +37,14 @@ const getStoragesConfig = (storagesConfig: IFileModuleConfig['storages'] = {}) =
     };
 };
 
+@Injectable()
 export class FileConfigService implements OnModuleInit, IFileModuleConfig {
     /**
      * Default storage (local)
      * Env:
      *  - APP_FILE_STORAGE_NAME
      */
-    public defaultStorageName: FileStorageEnum;
+    public defaultStorageName: FileStorageNameType;
 
     /**
      * Configurations for storages
@@ -108,7 +110,7 @@ export class FileConfigService implements OnModuleInit, IFileModuleConfig {
     public deleteLostAndTemporaryFilesByCron: {
         isEnable: boolean,
         cronTimePattern: string,
-        storageName: FileStorageEnum,
+        storageName: FileStorageNameType,
     };
 
     /**

--- a/src/domain/services/FileConfigService.ts
+++ b/src/domain/services/FileConfigService.ts
@@ -7,7 +7,6 @@ import FileStorageEnum from '../enums/FileStorageEnum';
 import FilePreviewEnum from '../enums/FilePreviewEnum';
 import {IFilePreviewOptions} from '../interfaces/IFilePreviewOptions';
 import {IFileModuleConfig} from '../../infrastructure/config';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 
 const getStoragesConfig = (storagesConfig: IFileModuleConfig['storages'] = {}) => {
     const localStorageConfig = {
@@ -44,7 +43,7 @@ export class FileConfigService implements OnModuleInit, IFileModuleConfig {
      * Env:
      *  - APP_FILE_STORAGE_NAME
      */
-    public defaultStorageName: FileStorageNameType;
+    public defaultStorageName: string;
 
     /**
      * Configurations for storages
@@ -110,7 +109,10 @@ export class FileConfigService implements OnModuleInit, IFileModuleConfig {
     public deleteLostAndTemporaryFilesByCron: {
         isEnable: boolean,
         cronTimePattern: string,
-        storageName: FileStorageNameType,
+        /**
+         * Storage name from FileModule storages config.
+         */
+        storageName: string,
     };
 
     /**
@@ -130,7 +132,7 @@ export class FileConfigService implements OnModuleInit, IFileModuleConfig {
 
     protected init(custom: IFileModuleConfig = {}) {
         // Default storage
-        this.defaultStorageName = process.env.APP_FILE_STORAGE_NAME as FileStorageEnum
+        this.defaultStorageName = process.env.APP_FILE_STORAGE_NAME
             || custom.defaultStorageName
             || FileStorageEnum.LOCAL;
 

--- a/src/domain/services/FileImageService.ts
+++ b/src/domain/services/FileImageService.ts
@@ -1,7 +1,6 @@
 import * as sharp from 'sharp';
 import {DataMapper} from '@steroidsjs/nest/usecases/helpers/DataMapper';
 import {ContextDto} from '@steroidsjs/nest/usecases/dtos/ContextDto';
-import {Inject, Optional} from '@nestjs/common';
 import {IFileImageRepository} from '../interfaces/IFileImageRepository';
 import {FileImageModel} from '../models/FileImageModel';
 import {FileModel} from '../models/FileModel';
@@ -13,11 +12,7 @@ import {IFilePreviewOptions} from '../interfaces/IFilePreviewOptions';
 import {FileRemovedEventDto} from '../dtos/events/FileRemovedEventDto';
 import {IEventEmitter} from '../interfaces/IEventEmitter';
 import {IFileStorageFactory} from '../interfaces/IFileStorageFactory';
-import FileStorageEnum from '../enums/FileStorageEnum';
-import {
-    GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN,
-    IGetFileStorageParamsUseCase,
-} from '../../usecases/getFileStorageParams/interfaces/IGetFileStorageParamsUseCase';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileConfigService} from './FileConfigService';
 
 const SVG_MIME_TYPE = 'image/svg+xml';
@@ -28,9 +23,6 @@ export class FileImageService {
         protected readonly fileConfigService: FileConfigService,
         protected readonly fileStorageFactory: IFileStorageFactory,
         protected readonly eventEmitter: IEventEmitter,
-        @Optional()
-        @Inject(GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN)
-        protected readonly getFileStorageParamsUseCase?: IGetFileStorageParamsUseCase,
     ) {
     }
 
@@ -121,10 +113,6 @@ export class FileImageService {
         });
 
         if (hasChanges) {
-            const fileStorageParams = this.getFileStorageParamsUseCase
-                ? await this.getFileStorageParamsUseCase.handle(file.fileType, file.storageName)
-                : null;
-
             await this.fileStorageFactory
                 .get(file.storageName)
                 .write(
@@ -133,16 +121,16 @@ export class FileImageService {
                         folder: imageModel.folder,
                         fileName: imageModel.fileName,
                         fileMimeType: file.fileMimeType,
+                        fileType: file.fileType,
                     }),
                     data,
-                    fileStorageParams,
                 );
         }
 
         return this.repository.create(imageModel);
     }
 
-    async getFilesPathsFromDb(storageName: FileStorageEnum): Promise<string[] | null> {
+    async getFilesPathsFromDb(storageName: FileStorageNameType): Promise<string[] | null> {
         return this.repository.getFilesPathsByStorageName(storageName);
     }
 

--- a/src/domain/services/FileImageService.ts
+++ b/src/domain/services/FileImageService.ts
@@ -12,7 +12,6 @@ import {IFilePreviewOptions} from '../interfaces/IFilePreviewOptions';
 import {FileRemovedEventDto} from '../dtos/events/FileRemovedEventDto';
 import {IEventEmitter} from '../interfaces/IEventEmitter';
 import {IFileStorageFactory} from '../interfaces/IFileStorageFactory';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileConfigService} from './FileConfigService';
 
 const SVG_MIME_TYPE = 'image/svg+xml';
@@ -130,7 +129,7 @@ export class FileImageService {
         return this.repository.create(imageModel);
     }
 
-    async getFilesPathsFromDb(storageName: FileStorageNameType): Promise<string[] | null> {
+    async getFilesPathsFromDb(storageName: string): Promise<string[] | null> {
         return this.repository.getFilesPathsByStorageName(storageName);
     }
 

--- a/src/domain/services/FileService.ts
+++ b/src/domain/services/FileService.ts
@@ -25,9 +25,7 @@ import {FileRemovedEventDto} from '../dtos/events/FileRemovedEventDto';
 import {IFileTypeService} from '../interfaces/IFileTypeService';
 import {IFileStorageFactory} from '../interfaces/IFileStorageFactory';
 import FileStorageEnum from '../enums/FileStorageEnum';
-import {
-    IGetFileStorageParamsUseCase,
-} from '../../usecases/getFileStorageParams/interfaces/IGetFileStorageParamsUseCase';
+import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileConfigService} from './FileConfigService';
 import {FileImageService} from './FileImageService';
 
@@ -48,7 +46,6 @@ export class FileService extends ReadService<FileModel> {
         protected readonly eventEmitter: IEventEmitter,
         protected readonly fileTypeService: IFileTypeService,
         public validators: IValidator[],
-        protected readonly getFileStorageParamsUseCase?: IGetFileStorageParamsUseCase,
     ) {
         super();
     }
@@ -129,14 +126,10 @@ export class FileService extends ReadService<FileModel> {
         // Get file stream from source
         const stream = await this.createStreamFromSource(options.source);
 
-        const fileStorageParams = this.getFileStorageParamsUseCase
-            ? await this.getFileStorageParamsUseCase.handle(options.fileType, options.storageName)
-            : null;
-
         // Save original file via storage
         const writeResult = await this.fileStorageFactory
             .get(options.storageName)
-            .write(fileDto, stream, fileStorageParams);
+            .write(fileDto, stream);
 
         // Delete temporary file
         const shouldDeleteTemporaryFile = !this.fileConfigService.saveTemporaryFileAfterUpload;
@@ -297,7 +290,7 @@ export class FileService extends ReadService<FileModel> {
         }
     }
 
-    async getFilesPathsFromDb(storageName: FileStorageEnum): Promise<string[] | null> {
+    async getFilesPathsFromDb(storageName: FileStorageNameType): Promise<string[] | null> {
         return this.repository.getFilesPathsByStorageName(storageName);
     }
 

--- a/src/domain/services/FileService.ts
+++ b/src/domain/services/FileService.ts
@@ -24,8 +24,6 @@ import {IEventEmitter} from '../interfaces/IEventEmitter';
 import {FileRemovedEventDto} from '../dtos/events/FileRemovedEventDto';
 import {IFileTypeService} from '../interfaces/IFileTypeService';
 import {IFileStorageFactory} from '../interfaces/IFileStorageFactory';
-import FileStorageEnum from '../enums/FileStorageEnum';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileConfigService} from './FileConfigService';
 import {FileImageService} from './FileImageService';
 
@@ -97,7 +95,7 @@ export class FileService extends ReadService<FileModel> {
 
         // Resolve storage name
         if (!options.storageName) {
-            options.storageName = this.fileConfigService.defaultStorageName as FileStorageEnum;
+            options.storageName = this.fileConfigService.defaultStorageName;
         }
 
         // Create FileModel from source
@@ -290,7 +288,7 @@ export class FileService extends ReadService<FileModel> {
         }
     }
 
-    async getFilesPathsFromDb(storageName: FileStorageNameType): Promise<string[] | null> {
+    async getFilesPathsFromDb(storageName: string): Promise<string[] | null> {
         return this.repository.getFilesPathsByStorageName(storageName);
     }
 

--- a/src/domain/services/FileStorageFactory.ts
+++ b/src/domain/services/FileStorageFactory.ts
@@ -1,8 +1,7 @@
 import {Inject, Injectable} from '@nestjs/common';
-import {IFileStorage} from '../interfaces/IFileStorage';
+import {FILE_STORAGES_TOKEN, IFileStorage} from '../interfaces/IFileStorage';
 import {IFileStorageFactory} from '../interfaces/IFileStorageFactory';
 import {FileStorageNameType} from '../types/FileStorageNameType';
-import {FILE_STORAGES_TOKEN} from '../storages';
 import {FileConfigService} from './FileConfigService';
 
 @Injectable()

--- a/src/domain/services/FileStorageFactory.ts
+++ b/src/domain/services/FileStorageFactory.ts
@@ -1,19 +1,23 @@
-import {FileConfigService} from './FileConfigService';
+import {Inject, Injectable} from '@nestjs/common';
 import {IFileStorage} from '../interfaces/IFileStorage';
-import { FileStorageEnum } from '../enums/FileStorageEnum';
-import { IFileStorageFactory } from '../interfaces/IFileStorageFactory';
+import {IFileStorageFactory} from '../interfaces/IFileStorageFactory';
+import {FileStorageNameType} from '../types/FileStorageNameType';
+import {FILE_STORAGES_TOKEN} from '../storages';
+import {FileConfigService} from './FileConfigService';
 
+@Injectable()
 export class FileStorageFactory implements IFileStorageFactory {
-    private initializedNames: FileStorageEnum[] = [];
+    private initializedNames: FileStorageNameType[] = [];
 
     constructor(
         private fileConfigService: FileConfigService,
-        private storages: Record<FileStorageEnum, IFileStorage>,
+        @Inject(FILE_STORAGES_TOKEN)
+        private storages: Record<FileStorageNameType, IFileStorage>,
     ) {
     }
 
-    public get(name: FileStorageEnum = null): IFileStorage {
-        name = name || this.fileConfigService.defaultStorageName as FileStorageEnum;
+    public get(name: FileStorageNameType = null): IFileStorage {
+        name = name || this.fileConfigService.defaultStorageName;
 
         if (!this.storages[name]) {
             throw new Error('Not found storage by name: ' + name);
@@ -24,7 +28,10 @@ export class FileStorageFactory implements IFileStorageFactory {
         if (!this.initializedNames.includes(name)) {
             this.initializedNames.push(name);
 
-            storage.init(this.fileConfigService.storages?.[name]);
+            const storageConfig = this.fileConfigService.storages?.[name] ?? {storageName: name};
+            storageConfig.storageName ??= name;
+
+            storage.init(storageConfig);
         }
 
         return storage;

--- a/src/domain/services/FileStorageFactory.ts
+++ b/src/domain/services/FileStorageFactory.ts
@@ -1,21 +1,20 @@
 import {Inject, Injectable} from '@nestjs/common';
 import {FILE_STORAGES_TOKEN, IFileStorage} from '../interfaces/IFileStorage';
 import {IFileStorageFactory} from '../interfaces/IFileStorageFactory';
-import {FileStorageNameType} from '../types/FileStorageNameType';
 import {FileConfigService} from './FileConfigService';
 
 @Injectable()
 export class FileStorageFactory implements IFileStorageFactory {
-    private initializedNames: FileStorageNameType[] = [];
+    private initializedNames: string[] = [];
 
     constructor(
         private fileConfigService: FileConfigService,
         @Inject(FILE_STORAGES_TOKEN)
-        private storages: Record<FileStorageNameType, IFileStorage>,
+        private storages: Record<string, IFileStorage>,
     ) {
     }
 
-    public get(name: FileStorageNameType = null): IFileStorage {
+    public get(name: string = null): IFileStorage {
         name = name || this.fileConfigService.defaultStorageName;
 
         if (!this.storages[name]) {

--- a/src/domain/storages/FileLocalStorage.ts
+++ b/src/domain/storages/FileLocalStorage.ts
@@ -4,13 +4,22 @@ import * as fs from 'fs';
 import * as md5File from 'md5-file';
 import {DataMapper} from '@steroidsjs/nest/usecases/helpers/DataMapper';
 import * as Sentry from '@sentry/node';
+import {Inject, Injectable, Optional, Scope} from '@nestjs/common';
 import {FileWriteResult} from '../dtos/FileWriteResult';
 import {IFileLocalStorage} from '../interfaces/IFileLocalStorage';
 import {IFileReadable} from '../interfaces/IFileReadable';
 import {IFileWritable} from '../interfaces/IFileWritable';
+import FileStorageEnum from '../enums/FileStorageEnum';
+import {
+    GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN,
+    IGetFileStorageParamsUseCase,
+} from '../../usecases/getFileStorageParams/interfaces/IGetFileStorageParamsUseCase';
 
 const DEFAULT_FILE_ENCODING: BufferEncoding = 'utf8';
 
+@Injectable({
+    scope: Scope.TRANSIENT,
+})
 export class FileLocalStorage implements IFileLocalStorage {
     /**
      * Absolute path to root user files dir
@@ -22,9 +31,19 @@ export class FileLocalStorage implements IFileLocalStorage {
      */
     public rootUrl: string;
 
+    public storageName: string;
+
+    constructor(
+        @Optional()
+        @Inject(GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN)
+        protected readonly getFileStorageParamsUseCase?: IGetFileStorageParamsUseCase,
+    ) {
+    }
+
     public init(config: any) {
         this.rootPath = config?.rootPath;
         this.rootUrl = config?.rootUrl;
+        this.storageName = config?.storageName ?? FileStorageEnum.LOCAL;
 
         if (!this.rootPath) {
             throw new Error('Not found file root path');
@@ -39,7 +58,6 @@ export class FileLocalStorage implements IFileLocalStorage {
     public async write(
         file: IFileWritable,
         source: Readable | Buffer,
-        fileStorageParams: Record<string, any> | null = {},
     ): Promise<FileWriteResult> {
         const dir = join(...[this.rootPath, file.folder].filter(Boolean));
 
@@ -50,9 +68,13 @@ export class FileLocalStorage implements IFileLocalStorage {
 
         const filePath = join(dir, file.fileName);
 
+        const fileTypeStorageParams = this.getFileStorageParamsUseCase
+            ? await this.getFileStorageParamsUseCase.handle(file.fileType, this.storageName)
+            : {};
+
         const options = {
             encoding: DEFAULT_FILE_ENCODING,
-            ...fileStorageParams,
+            ...fileTypeStorageParams,
         };
 
         await fs.promises.writeFile(filePath, source, options);

--- a/src/domain/storages/MinioS3Storage.ts
+++ b/src/domain/storages/MinioS3Storage.ts
@@ -3,12 +3,23 @@ import {toInteger as _toInteger} from 'lodash';
 import * as Minio from 'minio';
 import {DataMapper} from '@steroidsjs/nest/usecases/helpers/DataMapper';
 import {normalizeBoolean} from '@steroidsjs/nest/infrastructure/decorators/fields/BooleanField';
+import {Inject, Injectable, Optional, Scope} from '@nestjs/common';
 import {IFileStorage} from '../interfaces/IFileStorage';
 import {FileWriteResult} from '../dtos/FileWriteResult';
 import {IFileReadable} from '../interfaces/IFileReadable';
 import {IFileWritable} from '../interfaces/IFileWritable';
+import {
+    GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN,
+    IGetFileStorageParamsUseCase,
+} from '../../usecases/getFileStorageParams/interfaces/IGetFileStorageParamsUseCase';
+import FileStorageEnum from '../enums/FileStorageEnum';
 
+@Injectable({
+    scope: Scope.TRANSIENT,
+})
 export class MinioS3Storage implements IFileStorage {
+    public storageName: string;
+
     public host: string;
 
     public port: number;
@@ -29,6 +40,13 @@ export class MinioS3Storage implements IFileStorage {
 
     private _isBucketCreated: boolean;
 
+    constructor(
+        @Optional()
+        @Inject(GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN)
+        protected readonly getFileStorageParamsUseCase?: IGetFileStorageParamsUseCase,
+    ) {
+    }
+
     public init(config: any) {
         this.host = config?.host;
         this.port = _toInteger(config?.port);
@@ -38,6 +56,7 @@ export class MinioS3Storage implements IFileStorage {
         this.region = config?.region;
         this.mainBucket = config?.mainBucket;
         this.rootUrl = config?.rootUrl;
+        this.storageName = config?.storageName ?? FileStorageEnum.MINIO_S3;
 
         // if (!this.accessKey) {
         //     throw new Error('Not found accessKey for MinioS3Storage');
@@ -76,13 +95,16 @@ export class MinioS3Storage implements IFileStorage {
     public async write(
         file: IFileWritable,
         source: Readable | Buffer,
-        fileStorageParams: Record<string, any> | null = {},
     ): Promise<FileWriteResult> {
         await this.makeMainBucket();
 
+        const fileTypeStorageParams = this.getFileStorageParamsUseCase
+            ? await this.getFileStorageParamsUseCase.handle(file.fileType, this.storageName)
+            : {};
+
         const metaData = {
             'Content-Type': file.fileMimeType,
-            ...fileStorageParams,
+            ...fileTypeStorageParams,
         };
 
         return new Promise((resolve, reject) => {

--- a/src/domain/storages/index.ts
+++ b/src/domain/storages/index.ts
@@ -1,1 +1,0 @@
-export const FILE_STORAGES_TOKEN = 'file_storages_token';

--- a/src/domain/storages/index.ts
+++ b/src/domain/storages/index.ts
@@ -1,0 +1,1 @@
+export const FILE_STORAGES_TOKEN = 'file_storages_token';

--- a/src/domain/types/FileStorageNameType.ts
+++ b/src/domain/types/FileStorageNameType.ts
@@ -1,0 +1,3 @@
+import FileStorageEnum from '../enums/FileStorageEnum';
+
+export type FileStorageNameType = FileStorageEnum | string;

--- a/src/domain/types/FileStorageNameType.ts
+++ b/src/domain/types/FileStorageNameType.ts
@@ -1,3 +1,0 @@
-import FileStorageEnum from '../enums/FileStorageEnum';
-
-export type FileStorageNameType = FileStorageEnum | string;

--- a/src/infrastructure/commands/ClearLostAndTemporaryFilesCommand.ts
+++ b/src/infrastructure/commands/ClearLostAndTemporaryFilesCommand.ts
@@ -2,7 +2,8 @@
 import {Command, Option} from 'nestjs-command';
 import {Inject} from '@nestjs/common';
 import {DeleteLostAndTemporaryFilesService} from '../../domain/services/DeleteLostAndTemporaryFilesService';
-import {FileStorageEnum, FileStorageEnumHelper} from '../../domain/enums/FileStorageEnum';
+import {FileStorageEnum} from '../../domain/enums/FileStorageEnum';
+import {FileStorageNameType} from '../../domain/types/FileStorageNameType';
 
 export class ClearLostAndTemporaryFilesCommand {
     constructor(
@@ -22,10 +23,9 @@ export class ClearLostAndTemporaryFilesCommand {
             type: 'string',
             alias: 'st',
             demandOption: false,
-            choices: FileStorageEnumHelper.getKeys(),
             default: FileStorageEnum.LOCAL,
         })
-            storageName: FileStorageEnum,
+            storageName: FileStorageNameType,
 
         @Option({
             name: 'dry-run',

--- a/src/infrastructure/commands/ClearLostAndTemporaryFilesCommand.ts
+++ b/src/infrastructure/commands/ClearLostAndTemporaryFilesCommand.ts
@@ -3,7 +3,6 @@ import {Command, Option} from 'nestjs-command';
 import {Inject} from '@nestjs/common';
 import {DeleteLostAndTemporaryFilesService} from '../../domain/services/DeleteLostAndTemporaryFilesService';
 import {FileStorageEnum} from '../../domain/enums/FileStorageEnum';
-import {FileStorageNameType} from '../../domain/types/FileStorageNameType';
 
 export class ClearLostAndTemporaryFilesCommand {
     constructor(
@@ -25,7 +24,7 @@ export class ClearLostAndTemporaryFilesCommand {
             demandOption: false,
             default: FileStorageEnum.LOCAL,
         })
-            storageName: FileStorageNameType,
+            storageName: string,
 
         @Option({
             name: 'dry-run',

--- a/src/infrastructure/module.ts
+++ b/src/infrastructure/module.ts
@@ -18,7 +18,7 @@ import {FileRemovedEventHandleUseCase} from '../usecases/fileRemovedEventHandleU
 import {IFileTypeService} from '../domain/interfaces/IFileTypeService';
 import {FileTypeService} from '../domain/services/FileTypeService';
 import {IFileStorageFactory} from '../domain/interfaces/IFileStorageFactory';
-import {FILE_STORAGES_TOKEN} from '../domain/storages';
+import {FILE_STORAGES_TOKEN} from '../domain/interfaces/IFileStorage';
 import {FileEventsSubscriber} from './subscribers/FileEventsSubscriber';
 import {CronJobsRegister} from './services/CronJobsRegister';
 import {IFileModuleConfig} from './config';

--- a/src/infrastructure/module.ts
+++ b/src/infrastructure/module.ts
@@ -1,6 +1,7 @@
 import {ModuleHelper} from '@steroidsjs/nest/infrastructure/helpers/ModuleHelper';
 import {IFileService} from '@steroidsjs/nest-modules/file/services/IFileService';
 import {EventEmitter2} from '@nestjs/event-emitter';
+import {ModuleRef} from '@nestjs/core';
 import {IFileRepository} from '../domain/interfaces/IFileRepository';
 import {IFileImageRepository} from '../domain/interfaces/IFileImageRepository';
 import {FileService} from '../domain/services/FileService';
@@ -17,6 +18,7 @@ import {FileRemovedEventHandleUseCase} from '../usecases/fileRemovedEventHandleU
 import {IFileTypeService} from '../domain/interfaces/IFileTypeService';
 import {FileTypeService} from '../domain/services/FileTypeService';
 import {IFileStorageFactory} from '../domain/interfaces/IFileStorageFactory';
+import {FILE_STORAGES_TOKEN} from '../domain/storages';
 import {FileEventsSubscriber} from './subscribers/FileEventsSubscriber';
 import {CronJobsRegister} from './services/CronJobsRegister';
 import {IFileModuleConfig} from './config';
@@ -59,16 +61,17 @@ export default (config: IFileModuleConfig) => ({
         },
 
         {
-            inject: [FileConfigService, FileLocalStorage, MinioS3Storage],
-            provide: IFileStorageFactory,
-            useFactory: (
-                fileConfigService: FileConfigService,
-                fileLocalStorage: FileLocalStorage,
-                minioS3Storage: MinioS3Storage,
-            ) => new FileStorageFactory(fileConfigService, {
-                [FileStorageEnum.LOCAL]: fileLocalStorage,
-                [FileStorageEnum.MINIO_S3]: minioS3Storage,
+            provide: FILE_STORAGES_TOKEN,
+            inject: [ModuleRef],
+            useFactory: async (moduleRef: ModuleRef) => ({
+                [FileStorageEnum.LOCAL]: await moduleRef.resolve(FileLocalStorage),
+                [FileStorageEnum.MINIO_S3]: await moduleRef.resolve(MinioS3Storage),
             }),
+        },
+
+        {
+            provide: IFileStorageFactory,
+            useClass: FileStorageFactory,
         },
         ModuleHelper.provide(FileService, IFileService, [
             IFileRepository,

--- a/src/infrastructure/repositories/FileImageRepository.ts
+++ b/src/infrastructure/repositories/FileImageRepository.ts
@@ -6,7 +6,7 @@ import {IFileImageRepository} from '../../domain/interfaces/IFileImageRepository
 import {FileImageModel} from '../../domain/models/FileImageModel';
 import {FileImageTable} from '../tables/FileImageTable';
 import {IFileStorageFactory} from '../../domain/interfaces/IFileStorageFactory';
-import FileStorageEnum from '../../domain/enums/FileStorageEnum';
+import {FileStorageNameType} from '../../domain/types/FileStorageNameType';
 
 export class FileImageRepository extends CrudRepository<FileImageModel> implements IFileImageRepository {
     protected modelClass = FileImageModel;
@@ -26,7 +26,7 @@ export class FileImageRepository extends CrudRepository<FileImageModel> implemen
         return model;
     }
 
-    async getFilesPathsByStorageName(storageName: FileStorageEnum): Promise<string[] | null> {
+    async getFilesPathsByStorageName(storageName: FileStorageNameType): Promise<string[] | null> {
         const files = await this.createQuery()
             .select([
                 'fileName',

--- a/src/infrastructure/repositories/FileImageRepository.ts
+++ b/src/infrastructure/repositories/FileImageRepository.ts
@@ -6,7 +6,6 @@ import {IFileImageRepository} from '../../domain/interfaces/IFileImageRepository
 import {FileImageModel} from '../../domain/models/FileImageModel';
 import {FileImageTable} from '../tables/FileImageTable';
 import {IFileStorageFactory} from '../../domain/interfaces/IFileStorageFactory';
-import {FileStorageNameType} from '../../domain/types/FileStorageNameType';
 
 export class FileImageRepository extends CrudRepository<FileImageModel> implements IFileImageRepository {
     protected modelClass = FileImageModel;
@@ -26,7 +25,7 @@ export class FileImageRepository extends CrudRepository<FileImageModel> implemen
         return model;
     }
 
-    async getFilesPathsByStorageName(storageName: FileStorageNameType): Promise<string[] | null> {
+    async getFilesPathsByStorageName(storageName: string): Promise<string[] | null> {
         const files = await this.createQuery()
             .select([
                 'fileName',

--- a/src/infrastructure/repositories/FileRepository.ts
+++ b/src/infrastructure/repositories/FileRepository.ts
@@ -7,7 +7,7 @@ import {IFileRepository} from '../../domain/interfaces/IFileRepository';
 import {FileTable} from '../tables/FileTable';
 import {FileModel} from '../../domain/models/FileModel';
 import {IFileStorageFactory} from '../../domain/interfaces/IFileStorageFactory';
-import FileStorageEnum from '../../domain/enums/FileStorageEnum';
+import {FileStorageNameType} from '../../domain/types/FileStorageNameType';
 
 @Injectable()
 export class FileRepository extends CrudRepository<FileModel> implements IFileRepository {
@@ -42,7 +42,7 @@ export class FileRepository extends CrudRepository<FileModel> implements IFileRe
         return DataMapper.create(FileModel, file);
     }
 
-    async getFilesPathsByStorageName(storageName: FileStorageEnum): Promise<string[] | null> {
+    async getFilesPathsByStorageName(storageName: FileStorageNameType): Promise<string[] | null> {
         const files = await this.createQuery()
             .select([
                 'fileName',

--- a/src/infrastructure/repositories/FileRepository.ts
+++ b/src/infrastructure/repositories/FileRepository.ts
@@ -7,7 +7,6 @@ import {IFileRepository} from '../../domain/interfaces/IFileRepository';
 import {FileTable} from '../tables/FileTable';
 import {FileModel} from '../../domain/models/FileModel';
 import {IFileStorageFactory} from '../../domain/interfaces/IFileStorageFactory';
-import {FileStorageNameType} from '../../domain/types/FileStorageNameType';
 
 @Injectable()
 export class FileRepository extends CrudRepository<FileModel> implements IFileRepository {
@@ -42,7 +41,7 @@ export class FileRepository extends CrudRepository<FileModel> implements IFileRe
         return DataMapper.create(FileModel, file);
     }
 
-    async getFilesPathsByStorageName(storageName: FileStorageNameType): Promise<string[] | null> {
+    async getFilesPathsByStorageName(storageName: string): Promise<string[] | null> {
         const files = await this.createQuery()
             .select([
                 'fileName',

--- a/src/usecases/getFilePathModels/GetFileModelsPathUsecase.ts
+++ b/src/usecases/getFilePathModels/GetFileModelsPathUsecase.ts
@@ -1,7 +1,7 @@
 import {Inject, Injectable} from '@nestjs/common';
 import {FileService} from '../../domain/services/FileService';
 import {FileImageService} from '../../domain/services/FileImageService';
-import {FileStorageEnum} from '../../domain/enums/FileStorageEnum';
+import {FileStorageNameType} from '../../domain/types/FileStorageNameType';
 import {IGetFileModelsPathUsecase} from './interfaces/IGetFileModelsPathUsecase';
 
 @Injectable()
@@ -13,7 +13,7 @@ export class GetFileModelsPathUsecase implements IGetFileModelsPathUsecase {
         protected readonly fileImageService: FileImageService,
     ) {}
 
-    async handle(storageName: FileStorageEnum) {
+    async handle(storageName: FileStorageNameType) {
         return [
             ...await this.fileImageService.getFilesPathsFromDb(storageName),
             ...await this.fileService.getFilesPathsFromDb(storageName),

--- a/src/usecases/getFilePathModels/GetFileModelsPathUsecase.ts
+++ b/src/usecases/getFilePathModels/GetFileModelsPathUsecase.ts
@@ -1,7 +1,6 @@
 import {Inject, Injectable} from '@nestjs/common';
 import {FileService} from '../../domain/services/FileService';
 import {FileImageService} from '../../domain/services/FileImageService';
-import {FileStorageNameType} from '../../domain/types/FileStorageNameType';
 import {IGetFileModelsPathUsecase} from './interfaces/IGetFileModelsPathUsecase';
 
 @Injectable()
@@ -13,7 +12,7 @@ export class GetFileModelsPathUsecase implements IGetFileModelsPathUsecase {
         protected readonly fileImageService: FileImageService,
     ) {}
 
-    async handle(storageName: FileStorageNameType) {
+    async handle(storageName: string) {
         return [
             ...await this.fileImageService.getFilesPathsFromDb(storageName),
             ...await this.fileService.getFilesPathsFromDb(storageName),

--- a/src/usecases/getFilePathModels/interfaces/IGetFileModelsPathUsecase.ts
+++ b/src/usecases/getFilePathModels/interfaces/IGetFileModelsPathUsecase.ts
@@ -1,7 +1,7 @@
-import FileStorageEnum from '../../../domain/enums/FileStorageEnum';
+import {FileStorageNameType} from '../../../domain/types/FileStorageNameType';
 
 export const GetFileModelsPathUsecaseToken = 'GetFileModelsPathUsecaseToken';
 
 export interface IGetFileModelsPathUsecase {
-    handle: (storageName: FileStorageEnum) => Promise<string[]>
+    handle: (storageName: FileStorageNameType) => Promise<string[]>,
 }

--- a/src/usecases/getFilePathModels/interfaces/IGetFileModelsPathUsecase.ts
+++ b/src/usecases/getFilePathModels/interfaces/IGetFileModelsPathUsecase.ts
@@ -1,7 +1,5 @@
-import {FileStorageNameType} from '../../../domain/types/FileStorageNameType';
-
 export const GetFileModelsPathUsecaseToken = 'GetFileModelsPathUsecaseToken';
 
 export interface IGetFileModelsPathUsecase {
-    handle: (storageName: FileStorageNameType) => Promise<string[]>,
+    handle: (storageName: string) => Promise<string[]>,
 }

--- a/src/usecases/getFileStorageParams/interfaces/IGetFileStorageParamsUseCase.ts
+++ b/src/usecases/getFileStorageParams/interfaces/IGetFileStorageParamsUseCase.ts
@@ -4,5 +4,5 @@ export const GET_FILE_STORAGE_PARAMS_USE_CASE_TOKEN = 'get_file_storage_params_u
     Позволяет задать параметры загрузки файла в определенный тип хранилища
  */
 export interface IGetFileStorageParamsUseCase {
-    handle: (fileType: string, storageName: string) => Promise<Record<string, any>>,
+    handle: (fileType: string | undefined, storageName: string) => Promise<Record<string, any>>,
 }


### PR DESCRIPTION
https://gitlab.kozhindev.com/steroids/steroids-nest/-/issues/189

Вообще до этой задачи хранилища уже были подключены к DI, и они не создавались в классе FileStorageFactory, а инициализировались (вызывался init метод)

Из changelog:
- `IFileStorage.write` больше не принимает в качестве аргумента `fileStorageParams`, вместо этого хранилища сами берут эти настройки
из `IGetFileStorageParamsUseCase`
- Добавлен токен `FILE_STORAGES_TOKEN`, по которому провайдится объект с хранилищами и их названиями
- Хранилища теперь имеют injection scope `TRANSIENT`, что позволяет создать несколько экземпляров одного хранилища с разным конфигом
- Использование `FileStorageEnum` в качестве типа обновлено на `string`